### PR TITLE
feat(kubeconfig): merge fetched kubeconfig into shared ~/.kube/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ rpictl provision rpi3
 4. Use your cluster:
 
 ```bash
+# By default, rpictl merges the new context into ~/.kube/config so
+# `kubectl` picks it up without setting KUBECONFIG.
+kubectl --context=rpi3 get nodes
+
+# Or make it the default context:
+kubectl config use-context rpi3
+kubectl get nodes
+
+# Prefer an isolated kubeconfig? Disable merging in rpictl.yaml
+# (kubeconfig.merge: false) and use the per-host file directly:
 export KUBECONFIG=~/.kube/rpi3.yaml
 kubectl get nodes
 ```
@@ -94,7 +104,7 @@ kubectl get nodes
 | `memory` | zram + swappiness + `gpu_mem` in `/boot/firmware/config.txt` |
 | `prereqs` | Install curl, ca-certificates, gnupg, jq, git |
 | `k3s` | Install k3s via `get.k3s.io` |
-| `kubeconfig` | Fetch `/etc/rancher/k3s/k3s.yaml`, rewrite server address, write to laptop |
+| `kubeconfig` | Fetch `/etc/rancher/k3s/k3s.yaml`, rewrite server address, write to laptop, and merge into `~/.kube/config` |
 
 Each step is **idempotent** — re-running `rpictl provision` is safe.
 

--- a/examples/rpictl.yaml
+++ b/examples/rpictl.yaml
@@ -33,8 +33,11 @@ hosts:
       unattended_upgrades: true
 
     kubeconfig:
-      output: ~/.kube/rpi3.yaml     # where to write kubeconfig on laptop
+      output: ~/.kube/rpi3.yaml     # where to write the per-host kubeconfig
       context: rpi3                 # kubectl context name
+      merge: true                   # also merge into the shared kubeconfig (default: true)
+      merge_into: ~/.kube/config    # shared kubeconfig file (default: ~/.kube/config)
+      set_current: false            # set this context as current-context after merging
 
   # Example: Raspberry Pi 4 (4GB) — untested profile, best-effort defaults
   # rpi4:

--- a/internal/cli/kubeconfig.go
+++ b/internal/cli/kubeconfig.go
@@ -11,15 +11,22 @@ package cli
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
 	"github.com/idvoretskyi/rpictl/internal/config"
 	"github.com/idvoretskyi/rpictl/internal/orchestrator"
+	"github.com/spf13/cobra"
 )
 
 func newKubeconfigCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		merge      bool
+		noMerge    bool
+		setCurrent bool
+		mergeInto  string
+	)
+
+	cmd := &cobra.Command{
 		Use:   "kubeconfig <host>",
-		Short: "Fetch and write kubeconfig from an already-provisioned host",
+		Short: "Fetch kubeconfig from an already-provisioned host and (by default) merge it into ~/.kube/config",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			hostName := args[0]
@@ -35,7 +42,29 @@ func newKubeconfigCmd() *cobra.Command {
 				return err
 			}
 
+			// Apply CLI overrides. --no-merge takes precedence over --merge.
+			if cmd.Flags().Changed("merge") {
+				host.Kubeconfig.Merge = &merge
+			}
+			if cmd.Flags().Changed("no-merge") && noMerge {
+				f := false
+				host.Kubeconfig.Merge = &f
+			}
+			if cmd.Flags().Changed("set-current") {
+				host.Kubeconfig.SetCurrent = &setCurrent
+			}
+			if cmd.Flags().Changed("merge-into") {
+				host.Kubeconfig.MergeInto = mergeInto
+			}
+
 			return orchestrator.FetchKubeconfig(hostName, host)
 		},
 	}
+
+	cmd.Flags().BoolVar(&merge, "merge", true, "merge fetched kubeconfig into the shared kubeconfig file (default: true)")
+	cmd.Flags().BoolVar(&noMerge, "no-merge", false, "do not merge into the shared kubeconfig file")
+	cmd.Flags().BoolVar(&setCurrent, "set-current", false, "after merging, set this host's context as the current-context")
+	cmd.Flags().StringVar(&mergeInto, "merge-into", "", "shared kubeconfig file to merge into (default: ~/.kube/config)")
+
+	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,10 +86,15 @@ type UFWConfig struct {
 	AllowSSHFrom []string `yaml:"allow_ssh_from"`
 }
 
-// KubeconfigOut holds where to write the fetched kubeconfig.
+// KubeconfigOut holds where to write the fetched kubeconfig, and how to merge
+// it into a shared kubeconfig file (typically ~/.kube/config) so the local
+// kubectl can use it without setting KUBECONFIG.
 type KubeconfigOut struct {
-	Output  string `yaml:"output"`
-	Context string `yaml:"context"`
+	Output     string `yaml:"output"`
+	Context    string `yaml:"context"`
+	Merge      *bool  `yaml:"merge"`
+	MergeInto  string `yaml:"merge_into"`
+	SetCurrent *bool  `yaml:"set_current"`
 }
 
 var validate = validator.New()
@@ -194,6 +199,17 @@ func applyDefaults(name string, h *Host) error {
 	if h.Kubeconfig.Context == "" {
 		h.Kubeconfig.Context = name
 	}
+	if h.Kubeconfig.Merge == nil {
+		t := true
+		h.Kubeconfig.Merge = &t
+	}
+	if h.Kubeconfig.MergeInto == "" {
+		h.Kubeconfig.MergeInto = "~/.kube/config"
+	}
+	if h.Kubeconfig.SetCurrent == nil {
+		f := false
+		h.Kubeconfig.SetCurrent = &f
+	}
 
 	// Expand ~ in ssh_key, known_hosts_file, and kubeconfig output
 	if h.SSHKey != "" {
@@ -215,6 +231,11 @@ func applyDefaults(name string, h *Host) error {
 		return fmt.Errorf("expand kubeconfig.output: %w", err)
 	}
 	h.Kubeconfig.Output = expanded
+	mergeInto, err := expandHome(h.Kubeconfig.MergeInto)
+	if err != nil {
+		return fmt.Errorf("expand kubeconfig.merge_into: %w", err)
+	}
+	h.Kubeconfig.MergeInto = mergeInto
 
 	return nil
 }

--- a/internal/kubeconfig/merge.go
+++ b/internal/kubeconfig/merge.go
@@ -1,0 +1,151 @@
+// Copyright 2026 Ihor Dvoretskyi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package kubeconfig
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// kubeconfigFile is a minimal kubeconfig schema sufficient for merging.
+// Unknown fields are preserved verbatim via yaml.Node.
+type kubeconfigFile struct {
+	APIVersion     string           `yaml:"apiVersion,omitempty"`
+	Kind           string           `yaml:"kind,omitempty"`
+	CurrentContext string           `yaml:"current-context,omitempty"`
+	Preferences    *yaml.Node       `yaml:"preferences,omitempty"`
+	Clusters       []namedYAMLEntry `yaml:"clusters"`
+	Contexts       []namedYAMLEntry `yaml:"contexts"`
+	Users          []namedYAMLEntry `yaml:"users"`
+}
+
+// namedYAMLEntry is a generic { name: <string>, <key>: <node> } entry as
+// used in kubeconfig clusters / contexts / users lists. The payload is kept as
+// a yaml.Node so we round-trip unknown fields (certificate-authority-data,
+// client-key-data, etc.) without loss.
+type namedYAMLEntry struct {
+	Name    string    `yaml:"name"`
+	Cluster yaml.Node `yaml:"cluster,omitempty"`
+	Context yaml.Node `yaml:"context,omitempty"`
+	User    yaml.Node `yaml:"user,omitempty"`
+}
+
+// Merge merges the kubeconfig at srcPath into the kubeconfig at dstPath.
+//
+// Any cluster, context, or user named contextName already present in dst is
+// removed, then the matching entries from src are appended. If setCurrent is
+// true the merged file's current-context is set to contextName.
+//
+// If dstPath does not exist it is created (with mode 0600). The parent
+// directory is created if missing.
+//
+// Merge is intentionally implemented in pure Go and does not shell out to
+// kubectl, so it works on machines where kubectl is not installed.
+func Merge(srcPath, dstPath, contextName string, setCurrent bool) error {
+	src, err := readKubeconfig(srcPath)
+	if err != nil {
+		return fmt.Errorf("read source kubeconfig %s: %w", srcPath, err)
+	}
+
+	dst, err := readKubeconfigOrEmpty(dstPath)
+	if err != nil {
+		return fmt.Errorf("read destination kubeconfig %s: %w", dstPath, err)
+	}
+
+	// Default api headers when creating a fresh file.
+	if dst.APIVersion == "" {
+		dst.APIVersion = "v1"
+	}
+	if dst.Kind == "" {
+		dst.Kind = "Config"
+	}
+
+	dst.Clusters = filterOutNamed(dst.Clusters, contextName)
+	dst.Contexts = filterOutNamed(dst.Contexts, contextName)
+	dst.Users = filterOutNamed(dst.Users, contextName)
+
+	for _, c := range src.Clusters {
+		if c.Name == contextName {
+			dst.Clusters = append(dst.Clusters, c)
+		}
+	}
+	for _, c := range src.Contexts {
+		if c.Name == contextName {
+			dst.Contexts = append(dst.Contexts, c)
+		}
+	}
+	for _, u := range src.Users {
+		if u.Name == contextName {
+			dst.Users = append(dst.Users, u)
+		}
+	}
+
+	if setCurrent {
+		dst.CurrentContext = contextName
+	}
+
+	return writeKubeconfig(dstPath, dst)
+}
+
+func filterOutNamed(in []namedYAMLEntry, name string) []namedYAMLEntry {
+	out := in[:0:0]
+	for _, e := range in {
+		if e.Name == name {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func readKubeconfig(path string) (*kubeconfigFile, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is supplied by the user via config/flag
+	if err != nil {
+		return nil, err
+	}
+	var kc kubeconfigFile
+	if err := yaml.Unmarshal(data, &kc); err != nil {
+		return nil, fmt.Errorf("parse yaml: %w", err)
+	}
+	return &kc, nil
+}
+
+func readKubeconfigOrEmpty(path string) (*kubeconfigFile, error) {
+	kc, err := readKubeconfig(path)
+	if os.IsNotExist(err) {
+		return &kubeconfigFile{}, nil
+	}
+	return kc, err
+}
+
+func writeKubeconfig(path string, kc *kubeconfigFile) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("create kubeconfig dir: %w", err)
+	}
+
+	out, err := yaml.Marshal(kc)
+	if err != nil {
+		return fmt.Errorf("marshal yaml: %w", err)
+	}
+
+	// Preserve existing mode if the file already exists, otherwise create 0600.
+	mode := os.FileMode(0600)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+
+	// #nosec G306 -- mode is taken from existing file or defaults to 0600
+	if err := os.WriteFile(path, out, mode); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/kubeconfig/merge_test.go
+++ b/internal/kubeconfig/merge_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Ihor Dvoretskyi
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+package kubeconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const sampleSrc = `apiVersion: v1
+kind: Config
+current-context: rpi3bplus
+clusters:
+- name: rpi3bplus
+  cluster:
+    server: https://192.168.1.254:6443
+    certificate-authority-data: AAAA
+contexts:
+- name: rpi3bplus
+  context:
+    cluster: rpi3bplus
+    user: rpi3bplus
+users:
+- name: rpi3bplus
+  user:
+    client-certificate-data: BBBB
+    client-key-data: CCCC
+`
+
+const existingDst = `apiVersion: v1
+kind: Config
+current-context: docker-desktop
+clusters:
+- name: docker-desktop
+  cluster:
+    server: https://kubernetes.docker.internal:6443
+contexts:
+- name: docker-desktop
+  context:
+    cluster: docker-desktop
+    user: docker-desktop
+users:
+- name: docker-desktop
+  user:
+    client-certificate-data: ZZZZ
+`
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+func loadKC(t *testing.T, path string) *kubeconfigFile {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var kc kubeconfigFile
+	if err := yaml.Unmarshal(data, &kc); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return &kc
+}
+
+func TestMergeIntoMissingFileCreatesIt(t *testing.T) {
+	dir := t.TempDir()
+	src := writeFile(t, dir, "src.yaml", sampleSrc)
+	dst := filepath.Join(dir, "subdir", "config")
+
+	if err := Merge(src, dst, "rpi3bplus", true); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("expected 0600, got %o", perm)
+	}
+
+	kc := loadKC(t, dst)
+	if kc.CurrentContext != "rpi3bplus" {
+		t.Errorf("current-context = %q, want rpi3bplus", kc.CurrentContext)
+	}
+	if len(kc.Clusters) != 1 || kc.Clusters[0].Name != "rpi3bplus" {
+		t.Errorf("clusters = %+v", kc.Clusters)
+	}
+	if len(kc.Contexts) != 1 || kc.Contexts[0].Name != "rpi3bplus" {
+		t.Errorf("contexts = %+v", kc.Contexts)
+	}
+	if len(kc.Users) != 1 || kc.Users[0].Name != "rpi3bplus" {
+		t.Errorf("users = %+v", kc.Users)
+	}
+}
+
+func TestMergeIntoExistingPreservesOtherContexts(t *testing.T) {
+	dir := t.TempDir()
+	src := writeFile(t, dir, "src.yaml", sampleSrc)
+	dst := writeFile(t, dir, "config", existingDst)
+
+	if err := Merge(src, dst, "rpi3bplus", false); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	kc := loadKC(t, dst)
+	if kc.CurrentContext != "docker-desktop" {
+		t.Errorf("current-context must be preserved, got %q", kc.CurrentContext)
+	}
+
+	names := func(es []namedYAMLEntry) []string {
+		var out []string
+		for _, e := range es {
+			out = append(out, e.Name)
+		}
+		return out
+	}
+	got := names(kc.Contexts)
+	wantHas := map[string]bool{"docker-desktop": false, "rpi3bplus": false}
+	for _, n := range got {
+		if _, ok := wantHas[n]; ok {
+			wantHas[n] = true
+		}
+	}
+	for n, ok := range wantHas {
+		if !ok {
+			t.Errorf("context %q missing after merge; got %v", n, got)
+		}
+	}
+}
+
+func TestMergeReplacesSameNamedContext(t *testing.T) {
+	dir := t.TempDir()
+
+	// Pre-existing dst already has rpi3bplus pointing at an old IP.
+	oldDst := `apiVersion: v1
+kind: Config
+current-context: rpi3bplus
+clusters:
+- name: rpi3bplus
+  cluster:
+    server: https://10.0.0.1:6443
+contexts:
+- name: rpi3bplus
+  context:
+    cluster: rpi3bplus
+    user: rpi3bplus
+users:
+- name: rpi3bplus
+  user:
+    client-certificate-data: OLD
+`
+	src := writeFile(t, dir, "src.yaml", sampleSrc)
+	dst := writeFile(t, dir, "config", oldDst)
+
+	if err := Merge(src, dst, "rpi3bplus", true); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	kc := loadKC(t, dst)
+	if len(kc.Clusters) != 1 {
+		t.Fatalf("expected 1 cluster after replace, got %d", len(kc.Clusters))
+	}
+
+	// Serialize the cluster node and ensure the new server IP is present
+	// and the old one is gone.
+	data, err := yaml.Marshal(kc.Clusters[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(data)
+	if !contains(s, "192.168.1.254") {
+		t.Errorf("expected new server IP in merged cluster, got: %s", s)
+	}
+	if contains(s, "10.0.0.1") {
+		t.Errorf("expected old server IP to be removed, got: %s", s)
+	}
+}
+
+func TestMergePreservesDestinationFileMode(t *testing.T) {
+	dir := t.TempDir()
+	src := writeFile(t, dir, "src.yaml", sampleSrc)
+	dst := filepath.Join(dir, "config")
+	if err := os.WriteFile(dst, []byte(existingDst), 0640); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := Merge(src, dst, "rpi3bplus", false); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0640 {
+		t.Errorf("expected mode to be preserved as 0640, got %o", perm)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/orchestrator/provision.go
+++ b/internal/orchestrator/provision.go
@@ -105,10 +105,23 @@ func Provision(hostName string, host *config.Host, agentBinary []byte, force boo
 	}
 	fmt.Printf("  Kubeconfig written to %s\n", host.Kubeconfig.Output)
 
+	if err := mergeKubeconfig(host); err != nil {
+		return fmt.Errorf("kubeconfig merge: %w", err)
+	}
+
 	fmt.Printf("\nProvisioning complete in %s.\n\n", time.Since(start).Round(time.Second))
 	fmt.Printf("Next steps:\n")
-	fmt.Printf("  export KUBECONFIG=%s\n", host.Kubeconfig.Output)
-	fmt.Printf("  kubectl get nodes\n\n")
+	if host.Kubeconfig.Merge != nil && *host.Kubeconfig.Merge {
+		if host.Kubeconfig.SetCurrent != nil && *host.Kubeconfig.SetCurrent {
+			fmt.Printf("  kubectl get nodes    # context %q is already active\n\n", host.Kubeconfig.Context)
+		} else {
+			fmt.Printf("  kubectl --context=%s get nodes\n", host.Kubeconfig.Context)
+			fmt.Printf("  kubectl config use-context %s    # make it the default\n\n", host.Kubeconfig.Context)
+		}
+	} else {
+		fmt.Printf("  export KUBECONFIG=%s\n", host.Kubeconfig.Output)
+		fmt.Printf("  kubectl get nodes\n\n")
+	}
 	fmt.Printf("  cd infra/cloudflare && tofu init && tofu apply\n")
 	fmt.Printf("  flux bootstrap github --owner=<owner> --repository=<repo> --branch=main --path=clusters/rpi3 --personal\n")
 
@@ -320,8 +333,33 @@ func FetchKubeconfig(hostName string, host *config.Host) error {
 	}
 
 	fmt.Printf("Kubeconfig written to %s\n", host.Kubeconfig.Output)
-	fmt.Printf("  kubectl config use-context %s\n", host.Kubeconfig.Context)
 
+	if err := mergeKubeconfig(host); err != nil {
+		return fmt.Errorf("kubeconfig merge: %w", err)
+	}
+
+	if host.Kubeconfig.Merge == nil || !*host.Kubeconfig.Merge {
+		fmt.Printf("  kubectl --kubeconfig=%s config use-context %s\n", host.Kubeconfig.Output, host.Kubeconfig.Context)
+	}
+
+	return nil
+}
+
+// mergeKubeconfig merges the per-host kubeconfig into the shared kubeconfig
+// file (typically ~/.kube/config) if host.Kubeconfig.Merge is true. It is a
+// no-op when merge is disabled.
+func mergeKubeconfig(host *config.Host) error {
+	if host.Kubeconfig.Merge == nil || !*host.Kubeconfig.Merge {
+		return nil
+	}
+	setCurrent := host.Kubeconfig.SetCurrent != nil && *host.Kubeconfig.SetCurrent
+	if err := kubeconfig.Merge(host.Kubeconfig.Output, host.Kubeconfig.MergeInto, host.Kubeconfig.Context, setCurrent); err != nil {
+		return err
+	}
+	fmt.Printf("  Merged context %q into %s\n", host.Kubeconfig.Context, host.Kubeconfig.MergeInto)
+	if setCurrent {
+		fmt.Printf("  Set current-context to %q\n", host.Kubeconfig.Context)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- After provisioning, rpictl now merges the per-host kubeconfig into the shared kubeconfig (default `~/.kube/config`) so local `kubectl` works without setting `KUBECONFIG`.
- New config fields under `host.kubeconfig`: `merge` (default `true`), `merge_into` (default `~/.kube/config`), `set_current` (default `false`).
- New flags on `rpictl kubeconfig <host>`: `--merge` / `--no-merge` / `--merge-into` / `--set-current`.

## Implementation
- Pure-Go merge using `yaml.v3` round-trip; no `kubectl` dependency.
- Same-named clusters/contexts/users in the destination are filtered out before appending, so re-runs are idempotent and other contexts (e.g. `docker-desktop`) are preserved.
- Destination file mode is preserved if it exists, else created `0600`. Parent dir is `MkdirAll`'d with `0700`.
- Per-host file at `kubeconfig.output` remains the source of truth and is still written.

## Verification
- `go test ./...` green; `golangci-lint run` 0 issues; `gosec ./...` 0 issues.
- End-to-end against RPi 3B+: `rpictl kubeconfig rpi3bplus` merges alongside existing `docker-desktop` context; `kubectl --context=rpi3bplus get nodes` reports node `Ready` (k3s `v1.36.0+k3s1`).
- `--set-current` correctly flips `current-context` to `rpi3bplus`.

## Tests added
- `internal/kubeconfig/merge_test.go`:
  - merge into a missing file (creates with `0600`)
  - merge into existing file (preserves other contexts)
  - merge with same-named context (replaces, removes stale server IP)
  - merge preserves destination file mode (e.g. `0640`)